### PR TITLE
SE-455 Lusid Drive Url Env Var Change

### DIFF
--- a/sdk/lusid_drive/utilities/api_client_builder.py
+++ b/sdk/lusid_drive/utilities/api_client_builder.py
@@ -115,14 +115,14 @@ class ApiClientBuilder:
 
         # Use the access token provided if it exists
         if token is not None:
-            # Check that there is an api_url available
-            cls.__check_required_fields(configuration, ["api_url"])
+            # Check that there is an drive_url available
+            cls.__check_required_fields(configuration, ["drive_url"])
             api_token = token
         # Otherwise generate an access token from Okta and use a RefreshingToken going forward
         else:
             # Check that all the required fields for generating a token exist
             cls.__check_required_fields(configuration, [
-                "api_url",
+                "drive_url",
                 "password",
                 "username",
                 "client_id",
@@ -138,7 +138,7 @@ class ApiClientBuilder:
         # Initialise the API client using the token so that it can be included in all future requests
         config = Configuration()
         config.access_token = api_token
-        config.host = configuration.api_url
+        config.host = configuration.drive_url
 
         # Set the certificate from the configuration
         config.ssl_ca_cert = configuration.certificate_filename

--- a/sdk/lusid_drive/utilities/api_client_factory.py
+++ b/sdk/lusid_drive/utilities/api_client_factory.py
@@ -17,12 +17,12 @@ class ApiClientFactory:
     """
     def __init__(self, **kwargs):
         """
-        Iniitalise an ApiClientFactory by passing the token, api_url and app_name, or by
+        Iniitalise an ApiClientFactory by passing the token, drive_url and app_name, or by
         passing in the api_secrets_filename
 
         :param str token: Bearer token used to initialise the API
         :param str api_secrets_filename: Name of secrets file (including full path)
-        :param str api_url: LUSID API url
+        :param str drive_url: LUSID Drive url
         :param str app_name: Application name (optional)
         :param str certificate_filename: Name of the certificate file (.pem, .cer or .crt)
         :param str proxy_url: The url of the proxy to use including the port e.g. http://myproxy.com:8888
@@ -35,7 +35,7 @@ class ApiClientFactory:
         if "token" in kwargs and str(kwargs["token"]) != "None":
             # If there is a token use it along with the specified proxy details if specified
             config = ApiConfiguration(
-                api_url=kwargs.get("api_url", None),
+                drive_url=kwargs.get("drive_url", None),
                 certificate_filename=kwargs.get("certificate_filename", None),
                 proxy_config=ProxyConfig(
                     address=kwargs.get("proxy_url", None),

--- a/sdk/lusid_drive/utilities/api_configuration.py
+++ b/sdk/lusid_drive/utilities/api_configuration.py
@@ -1,12 +1,12 @@
 class ApiConfiguration:
 
-    def __init__(self, token_url=None, api_url=None, username=None, password=None, client_id=None, client_secret=None,
+    def __init__(self, token_url=None, drive_url=None, username=None, password=None, client_id=None, client_secret=None,
                  app_name=None, certificate_filename=None, proxy_config=None, api_token=None):
         """
         The configuration required to access LUSID, read more at https://support.finbourne.com/getting-started-with-apis-sdks
 
         :param str token_url: The token URL of the identity provider
-        :param str api_url: The API URL for the LUSID client
+        :param str drive_url: The Drive URL for the LUSID client
         :param str username: The username to use
         :param str password: The password to use
         :param str client_id: The client id to use
@@ -17,7 +17,7 @@ class ApiConfiguration:
         :param lusid_drive.utilities.ProxyConfig proxy_config: The proxy configuration to use
         """
         self.__token_url = token_url
-        self.__api_url = api_url
+        self.__drive_url = drive_url
         self.__username = username
         self.__password = password
         self.__client_id = client_id
@@ -44,12 +44,12 @@ class ApiConfiguration:
         self.__token_url = value
 
     @property
-    def api_url(self):
-        return self.__api_url
+    def drive_url(self):
+        return self.__drive_url
 
-    @api_url.setter
-    def api_url(self, value):
-        self.__api_url = value
+    @drive_url.setter
+    def drive_url(self, value):
+        self.__drive_url = value
 
     @property
     def username(self):

--- a/sdk/lusid_drive/utilities/config_keys.json
+++ b/sdk/lusid_drive/utilities/config_keys.json
@@ -3,9 +3,9 @@
       "env": "FBN_TOKEN_URL",
       "config": "tokenUrl"
   },
-  "api_url": {
+  "drive_url": {
       "env": "FBN_DRIVE_API_URL",
-      "config": "apiUrl"
+      "config": "driveUrl"
   },
   "username": {
       "env": "FBN_USERNAME",

--- a/sdk/tests/test_lusid_drive.py
+++ b/sdk/tests/test_lusid_drive.py
@@ -21,9 +21,7 @@ class LusidDriveTests(unittest.TestCase):
 
         config = ApiConfigurationLoader.load("secrets.json")
 
-        # Will default to using bearer token first otherwise will attempt to use OAuth credentials from secrets.json
-        cls.api_factory = ApiClientFactory(token=config.api_token, drive_url=config.drive_url,
-                                           api_secrets_filename="secrets.json")
+        cls.api_factory = ApiClientFactory(token=config.api_token, api_url=config.drive_url)
         cls.folder_api = cls.api_factory.build(lusid_drive.api.FoldersApi)
         cls.files_api = cls.api_factory.build(lusid_drive.api.FilesApi)
 

--- a/sdk/tests/test_lusid_drive.py
+++ b/sdk/tests/test_lusid_drive.py
@@ -21,7 +21,9 @@ class LusidDriveTests(unittest.TestCase):
 
         config = ApiConfigurationLoader.load("secrets.json")
 
-        cls.api_factory = ApiClientFactory(token=config.api_token, api_url=config.api_url)
+        # Will default to using bearer token first otherwise will attempt to use OAuth credentials from secrets.json
+        cls.api_factory = ApiClientFactory(token=config.api_token, drive_url=config.drive_url,
+                                           api_secrets_filename="secrets.json")
         cls.folder_api = cls.api_factory.build(lusid_drive.api.FoldersApi)
         cls.files_api = cls.api_factory.build(lusid_drive.api.FilesApi)
 


### PR DESCRIPTION
Changing environment variable and secrets parameters to retrieve LUSID Drive URL from FBN_LUSID_API_URL to FBN_LUSID_DRIVE_URL to prevent any clashes when using both lusid api and drive sdks within an application.