### PR TITLE
CTECH-2320 Drive SDK hand IssuerUrl with Tests

### DIFF
--- a/sdk/lusid_drive/utilities/api_configuration.py
+++ b/sdk/lusid_drive/utilities/api_configuration.py
@@ -1,3 +1,6 @@
+import re
+
+
 class ApiConfiguration:
 
     def __init__(self, token_url=None, drive_url=None, username=None, password=None, client_id=None, client_secret=None,
@@ -16,7 +19,7 @@ class ApiConfiguration:
         :param str certificate_filename: Name of the certificate file (.pem, .cer or .crt)
         :param lusid_drive.utilities.ProxyConfig proxy_config: The proxy configuration to use
         """
-        self.__token_url = token_url
+        self.token_url = token_url
         self.__drive_url = drive_url
         self.__username = username
         self.__password = password
@@ -41,7 +44,22 @@ class ApiConfiguration:
 
     @token_url.setter
     def token_url(self, value):
-        self.__token_url = value
+        def format_token_url(url: str) -> str:
+            """
+            Given an Okta issuer url (ie: https://lusid-testdomain.okta.com/oauth2/asd8f7a98sdf89a7ad), this function
+            will return a full token url (ie: https://lusid-testdomain.okta.com/oauth2/asd8f7a98sdf89a7ad/v1/token)
+            :param url: The url to format
+            :return: An Okta token url (if the input is an Okta issuer url). The original url otherwise.
+            """
+            if (url is not None and
+                    # and it's an Okta oauth2 URL
+                    re.search('^http(s)?:\/\/.*\.okta\.com\/oauth2\/.+', url, flags=re.IGNORECASE) is not None and
+                    # and it's missing the token suffix
+                    re.search('\/v\d+\/token$', url, flags=re.IGNORECASE) is None):
+                return url.rstrip('/') + '/v1/token'
+            return url
+
+        self.__token_url = format_token_url(value)
 
     @property
     def drive_url(self):

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -3,3 +3,5 @@ six >= 1.10
 certifi >= 2021.10.8
 python-dateutil >= 2.5.3
 requests >= 2.26.0
+parameterized~=0.8.1
+setuptools~=60.2.0

--- a/sdk/tests/test_api_configuration.py
+++ b/sdk/tests/test_api_configuration.py
@@ -1,0 +1,40 @@
+import unittest
+
+from parameterized import parameterized
+
+from lusid_drive import ApiConfiguration
+
+
+class ApiConfigurationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.valid_okta_url_regex = '^http(s)?:\/\/.*\.okta\.com\/oauth2\/.*\/v\d+\/token$'
+
+    @parameterized.expand([
+        # Okta urls without proper suffix
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f',
+        # Okta urls with proper suffix
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token/',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token/',
+        # 2 digit version
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/'
+    ])
+    def test_okta_token_url_without_proper_suffix(self, token_url):
+        api_config = ApiConfiguration(token_url=token_url)
+        self.assertRegex(api_config.token_url, self.valid_okta_url_regex)
+
+    @parameterized.expand([
+        # Non okta urls with a token suffix
+        'https://foo.bar.com/oauth2/asd34fhas34dufhasdf/v1/token',
+        'https://foo.bar.com/oauth2/asdfh756asdufhasdf/v1/token/',
+        # Non okta urls without a token suffix
+        'https://foo.bar.com/oauth2/asd34fhas34dufhasdf',
+        'https://foo.bar.com/oauth2/asdfh756asdufhasdf/'
+    ])
+    def test_non_okta_token_url_with_proper_suffix(self, token_url):
+        api_config = ApiConfiguration(token_url=token_url)
+        self.assertEqual(api_config.token_url, token_url)


### PR DESCRIPTION
This MR copies logic from the LUSID SDK where it can handle an IssuerUrl for a TokenUrl. I have copied to corresponding tests for this too and they all pass along with existing ones.
