### PR TITLE
CTECH-3042: Make tests use random names so can be run in parallel.

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,14 +1,9 @@
-FROM python:3.7.0
+FROM python:3.11.3
 
 WORKDIR /usr/src/
-
-RUN apt-get update && apt-get -y install jq
 
 COPY requirements.txt requirements.dev.txt /usr/src/
 
 RUN pip install --no-cache-dir -r requirements.txt -r requirements.dev.txt
 
-RUN pip --no-cache-dir install --upgrade awscli
-
-#CMD /bin/bash
 ENTRYPOINT PYTHONPATH=/usr/src/:/usr/src/tests python -m unittest discover -v

--- a/sdk/tests/test_file_streaming.py
+++ b/sdk/tests/test_file_streaming.py
@@ -15,6 +15,7 @@ from lusid_drive import (
 )
 from lusid_drive.utilities import ApiClientFactory, get_file_id, get_folder_id
 from lusid_drive.utilities.file_streaming import stream_file_upload
+import lusid_drive
 
 
 class FileStreaming(unittest.TestCase):
@@ -109,9 +110,12 @@ class FileStreaming(unittest.TestCase):
         # delete download test file
         delete_file(cls.download_test_file_name, cls.test_folder_name)
 
-        # delete test folder
-        folder_id = get_folder_id(cls.api_factory, cls.test_folder_name)
-        cls.folder_api.delete_folder(folder_id)
+        try:
+            # delete test folder
+            folder_id = get_folder_id(cls.api_factory, cls.test_folder_name)
+            cls.folder_api.delete_folder(folder_id)
+        except lusid_drive.ApiException:
+            cls.logger.exception(f"failed to delete folder: {cls.test_folder_name}")
 
     def test_stream_file_download(self):
         # arrange

--- a/sdk/tests/test_file_streaming.py
+++ b/sdk/tests/test_file_streaming.py
@@ -2,12 +2,22 @@ import json
 import logging
 import os
 import unittest
+import uuid
 
-from lusid_drive import ApiConfigurationLoader, SearchApi, SearchBody, FilesApi, FoldersApi, ApiException, models
+from lusid_drive import (
+    ApiConfigurationLoader,
+    SearchApi,
+    SearchBody,
+    FilesApi,
+    FoldersApi,
+    ApiException,
+    models,
+)
 from lusid_drive.utilities import ApiClientFactory, get_file_id, get_folder_id
 from lusid_drive.utilities.file_streaming import stream_file_upload
-class FileStreaming(unittest.TestCase):
 
+
+class FileStreaming(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.logger = logging.getLogger()
@@ -17,19 +27,27 @@ class FileStreaming(unittest.TestCase):
         cls.api_factory = ApiClientFactory(
             token=config.api_token,
             drive_url=config.drive_url,
-            api_secrets_filename=os.path.join(os.getcwd(), "secrets.json"))
+            api_secrets_filename=os.path.join(os.getcwd(), "secrets.json"),
+        )
 
         cls.folder_api = cls.api_factory.build(FoldersApi)
         cls.files_api = cls.api_factory.build(FilesApi)
 
-        cls.test_folder_name = "sdk-test-folder"
-        cls.create_test_file_name = "create_test_stream_file.txt"
-        cls.download_test_file_name = "download_test_stream_file.txt"
-        cls.local_file_path = os.path.join(os.path.dirname(__file__), "data", "test_stream_file.txt")
+        # folders must be <50 chars
+        short_folder_uuid = str(uuid.uuid4())[:8]
+
+        cls.test_folder_name = f"sdk-test-folder_{short_folder_uuid}"
+        cls.create_test_file_name = f"create_test_stream_file_{uuid.uuid4()}.txt"
+        cls.download_test_file_name = f"download_test_stream_file_{uuid.uuid4()}.txt"
+        cls.local_file_path = os.path.join(
+            os.path.dirname(__file__), "data", "test_stream_file.txt"
+        )
 
         # create the test folder
         try:
-            cls.folder_api.create_folder(models.CreateFolder(path="/", name=cls.test_folder_name))
+            cls.folder_api.create_folder(
+                models.CreateFolder(path="/", name=cls.test_folder_name)
+            )
         except ApiException as e:
             if json.loads(e.body)["code"] == 664:
                 # a folder with this name already exists in the path
@@ -39,12 +57,12 @@ class FileStreaming(unittest.TestCase):
 
         def create_file(file_name, folder_name, local_path):
             try:
-                with open(local_path, 'rb') as data:
+                with open(local_path, "rb") as data:
                     response = cls.files_api.create_file(
                         x_lusid_drive_filename=file_name,
                         x_lusid_drive_path=f"/{folder_name}",
                         content_length=os.stat(local_path).st_size,
-                        body=data.read()
+                        body=data.read(),
                     )
 
                 if file_name not in response.name:
@@ -58,7 +76,9 @@ class FileStreaming(unittest.TestCase):
                     cls.logger.info(json.loads(e.body)["detail"])
 
         # create the test files for the download test
-        create_file(cls.download_test_file_name, cls.test_folder_name, cls.local_file_path)
+        create_file(
+            cls.download_test_file_name, cls.test_folder_name, cls.local_file_path
+        )
 
         # make sure the file to be created in the upload test does not already exist
         try:
@@ -71,11 +91,12 @@ class FileStreaming(unittest.TestCase):
 
         except ApiException as e:
             # either the folder or the file does not exist
-            cls.logger.info("File or directory does not exist" + ":" + json.loads(e.body)["detail"])
+            cls.logger.info(
+                "File or directory does not exist" + ":" + json.loads(e.body)["detail"]
+            )
 
     @classmethod
     def tearDownClass(cls) -> None:
-
         def delete_file(file_name, folder_name):
             _folder_id = get_folder_id(cls.api_factory, folder_name)
             _file_id = get_file_id(cls.api_factory, file_name, _folder_id)
@@ -95,38 +116,42 @@ class FileStreaming(unittest.TestCase):
     def test_stream_file_download(self):
         # arrange
         response = self.api_factory.build(SearchApi).search(
-            search_body=SearchBody(with_path=f"/{self.test_folder_name}", name=self.download_test_file_name)
+            search_body=SearchBody(
+                with_path=f"/{self.test_folder_name}", name=self.download_test_file_name
+            )
         )
 
         if response.values is None or len(response.values) != 1:
             self.fail(
                 f"Unexpected result for path {'/'.join([self.test_folder_name, self.download_test_file_name])}, "
-                f"{len(response.values)} results returned")
+                f"{len(response.values)} results returned"
+            )
 
         with open(self.local_file_path, "r") as local_file:
             expected = local_file.read()
 
         # act
-        with self.api_factory.build(FilesApi).download_file(response.values[0].id, _preload_content=False) as stream:
-
+        with self.api_factory.build(FilesApi).download_file(
+            response.values[0].id, _preload_content=False
+        ) as stream:
             # assert
             actual = stream.read().decode("utf-8")
             self.assertEqual(actual, expected)
 
     def test_stream_file_upload(self):
         # arrange
-        with open(self.local_file_path, 'rb') as data:
+        with open(self.local_file_path, "rb") as data:
             # act
             response = stream_file_upload(
                 x_lusid_drive_filename=self.create_test_file_name,
                 x_lusid_drive_path=f"/{self.test_folder_name}",
                 content_length=os.stat(self.local_file_path).st_size,
                 body=data,
-                api_factory=self.api_factory
+                api_factory=self.api_factory,
             )
             # assert
             self.assertEqual(self.create_test_file_name, response.name)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/tests/test_lusid_drive.py
+++ b/sdk/tests/test_lusid_drive.py
@@ -10,11 +10,16 @@ from lusid_drive.utilities import ApiClientFactory
 from lusid_drive.utilities.wait_for_virus_scan import WaitForVirusScan
 from lusid_drive.utilities import ApiConfigurationLoader
 from lusid_drive.utilities.folders_api_extensions import (
-    create_all_folders_in_path, delete_folder,
-    path_to_search_api_parms, drive_path_formatter,
-    drive_object_to_id)
+    create_all_folders_in_path,
+    delete_folder,
+    path_to_search_api_parms,
+    drive_path_formatter,
+    drive_object_to_id,
+)
 from unittest.mock import patch, Mock
 from parameterized import parameterized
+import uuid
+
 
 class MockApiResponse(object):
     def __init__(self, status=None):
@@ -23,10 +28,8 @@ class MockApiResponse(object):
 
 
 class LusidDriveTests(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
-
         cls.logger = logging.getLogger()
         cls.logger.setLevel(logging.INFO)
 
@@ -35,21 +38,29 @@ class LusidDriveTests(unittest.TestCase):
         cls.api_factory = ApiClientFactory(
             token=config.api_token,
             drive_url=config.drive_url,
-            api_secrets_filename=os.path.join(os.getcwd(), "secrets.json"))
+            api_secrets_filename=os.path.join(os.getcwd(), "secrets.json"),
+        )
 
         cls.folder_api = cls.api_factory.build(lusid_drive.api.FoldersApi)
         cls.files_api = cls.api_factory.build(lusid_drive.api.FilesApi)
         cls.search_api = cls.api_factory.build(lusid_drive.api.SearchApi)
 
-        cls.test_folder_name = "sdk-test-folder"
-        cls.create_test_file_name = "create_test_file.txt"
-        cls.download_test_file_name = "download_test_file.txt"
-        cls.delete_test_file_name = "delete_test_file.txt"
-        cls.local_file_path = os.path.join(os.path.dirname(__file__), "data", "test_file.txt")
+        # folders must be <50 chars
+        short_folder_uuid = str(uuid.uuid4())[:8]
+
+        cls.test_folder_name = f"sdk-test-folder_{short_folder_uuid}"
+        cls.create_test_file_name = f"create_test_file_{uuid.uuid4()}.txt"
+        cls.download_test_file_name = f"download_test_file_{uuid.uuid4()}.txt"
+        cls.delete_test_file_name = f"delete_test_file_{uuid.uuid4()}.txt"
+        cls.local_file_path = os.path.join(
+            os.path.dirname(__file__), "data", "test_file.txt"
+        )
 
         # create the test folder
         try:
-            cls.folder_api.create_folder(models.CreateFolder(path="/", name=cls.test_folder_name))
+            cls.folder_api.create_folder(
+                models.CreateFolder(path="/", name=cls.test_folder_name)
+            )
 
         except lusid_drive.exceptions.ApiException as e:
             if json.loads(e.body)["code"] == 664:
@@ -60,12 +71,12 @@ class LusidDriveTests(unittest.TestCase):
 
         def create_file(file_name, folder_name, local_path):
             try:
-                with open(local_path, 'rb') as data:
+                with open(local_path, "rb") as data:
                     response = cls.files_api.create_file(
                         x_lusid_drive_filename=file_name,
                         x_lusid_drive_path=f"/{folder_name}",
                         content_length=os.stat(local_path).st_size,
-                        body=data.read()
+                        body=data.read(),
                     )
 
                 if file_name not in response.name:
@@ -79,15 +90,21 @@ class LusidDriveTests(unittest.TestCase):
                     cls.logger.info(json.loads(e.body)["detail"])
 
         # create the test files for the download test
-        create_file(cls.download_test_file_name, cls.test_folder_name, cls.local_file_path)
+        create_file(
+            cls.download_test_file_name, cls.test_folder_name, cls.local_file_path
+        )
 
         # create the test files for the delete test
-        create_file(cls.delete_test_file_name, cls.test_folder_name, cls.local_file_path)
+        create_file(
+            cls.delete_test_file_name, cls.test_folder_name, cls.local_file_path
+        )
 
         # make sure the file to be created in the create test does not already exist
         try:
             folder_id = utilities.get_folder_id(cls.api_factory, cls.test_folder_name)
-            file_id = utilities.get_file_id(cls.api_factory, cls.create_test_file_name, folder_id)
+            file_id = utilities.get_file_id(
+                cls.api_factory, cls.create_test_file_name, folder_id
+            )
             if file_id is not None:
                 cls.files_api.delete_file(file_id)
             else:
@@ -95,11 +112,12 @@ class LusidDriveTests(unittest.TestCase):
 
         except lusid_drive.exceptions.ApiException as e:
             # either the folder or the file does not exist
-            cls.logger.info("File or directory does not exist" + ":" + json.loads(e.body)["detail"])
+            cls.logger.info(
+                "File or directory does not exist" + ":" + json.loads(e.body)["detail"]
+            )
 
     @classmethod
     def tearDownClass(cls) -> None:
-
         def delete_file(file_name, folder_name):
             _folder_id = utilities.get_folder_id(cls.api_factory, folder_name)
             _file_id = utilities.get_file_id(cls.api_factory, file_name, _folder_id)
@@ -120,71 +138,80 @@ class LusidDriveTests(unittest.TestCase):
         cls.folder_api.delete_folder(folder_id)
 
     def test_get_folder(self):
+        get_folder = self.folder_api.get_root_folder(
+            filter=f"name eq '{self.test_folder_name}' and type eq 'Folder'"
+        )
 
-        get_folder = self.folder_api.get_root_folder(filter=f"name eq '{self.test_folder_name}' and type eq 'Folder'")
-
-        list_root_contents = ([folder.name for folder in get_folder.values])
+        list_root_contents = [folder.name for folder in get_folder.values]
 
         self.assertEqual([self.test_folder_name], list_root_contents)
 
     def test_create_file(self):
-
-        with open(self.local_file_path, 'rb') as data:
+        with open(self.local_file_path, "rb") as data:
             response = self.files_api.create_file(
                 x_lusid_drive_filename=self.create_test_file_name,
                 x_lusid_drive_path=f"/{self.test_folder_name}",
                 content_length=os.stat(self.local_file_path).st_size,
-                body=data.read()
+                body=data.read(),
             )
             self.assertEqual(self.create_test_file_name, response.name)
 
     def test_download_file(self):
-
         folder_id = utilities.get_folder_id(self.api_factory, self.test_folder_name)
-        file_id = utilities.get_file_id(self.api_factory, self.download_test_file_name, folder_id)
+        file_id = utilities.get_file_id(
+            self.api_factory, self.download_test_file_name, folder_id
+        )
         response = self.files_api.download_file(file_id)
         self.assertIn(self.download_test_file_name, response)
 
     def _test_virus_scan(self):
-
         folder_id = utilities.get_folder_id(self.api_factory, self.test_folder_name)
 
         mock_download = Mock()
         mock_download.side_effect = [
             ApiException(status=423),
             ApiException(status=423),
-            MockApiResponse(status=201)
+            MockApiResponse(status=201),
         ]
 
-        with patch.object(FilesApi, "download_file", side_effect=mock_download) as download_mock:
+        with patch.object(
+            FilesApi, "download_file", side_effect=mock_download
+        ) as download_mock:
             wait = WaitForVirusScan(self.files_api)
-            download = wait.download_file_with_retry(folder_id)
+            wait.download_file_with_retry(folder_id)
 
             self.assertEqual(3, download_mock.call_count)
 
     def test_delete_file(self):
-
         folder_id = utilities.get_folder_id(self.api_factory, self.test_folder_name)
-        file_id = utilities.get_file_id(self.api_factory, self.delete_test_file_name, folder_id)
+        file_id = utilities.get_file_id(
+            self.api_factory, self.delete_test_file_name, folder_id
+        )
         response = self.files_api.delete_file(file_id)
         self.assertEqual(None, response)
 
-    @parameterized.expand([
-        ["/sdk-tests-delete-folder-1/test1/test2"],
-        ["sdk-tests-delete-folder/test1/test2"],
-        ["/sdk-tests-delete-folder-1"],
-        ["sdk-tests-delete-folder"]
-    ])
+    @parameterized.expand(
+        [
+            ["/sdk-tests-delete-folder-1/test1/test2"],
+            ["sdk-tests-delete-folder/test1/test2"],
+            ["/sdk-tests-delete-folder-1"],
+            ["sdk-tests-delete-folder"],
+        ]
+    )
     def test_create_folder(self, folder_name):
-
-        create_folder_request = create_all_folders_in_path(self.api_factory, folder_name)
+        create_folder_request = create_all_folders_in_path(
+            self.api_factory, folder_name
+        )
 
         search_api_params = path_to_search_api_parms(folder_name)
         path_for_search_api = search_api_params[0]
         name_for_search_api = search_api_params[1]
 
-        get_folder = self.search_api.search(search_body=models.SearchBody(
-            with_path=path_for_search_api, name=name_for_search_api))
+        get_folder = self.search_api.search(
+            search_body=models.SearchBody(
+                with_path=path_for_search_api, name=name_for_search_api
+            )
+        )
 
         get_folder_path = get_folder.values[0].path
         get_folder_name = get_folder.values[0].name
@@ -195,57 +222,62 @@ class LusidDriveTests(unittest.TestCase):
         big_string_path = "/abc" * 1000
 
         with self.assertRaises(ValueError) as error:
+            create_all_folders_in_path(self.api_factory, big_string_path)
 
-            create_folder_request = create_all_folders_in_path(self.api_factory, big_string_path)
+        self.assertEqual(
+            str(error.exception), "Path length must be less than 1024 characters"
+        )
 
-        self.assertEqual(str(error.exception), 'Path length must be less than 1024 characters')
-
-    @parameterized.expand([
-        ["/sdk-tests-delete-folder-1/test1/test2"],
-        ["sdk-tests-delete-folder/test1/test2"],
-        ["/sdk-tests-delete-folder-1"],
-        ["sdk-tests-delete-folder"]
-    ])
+    @parameterized.expand(
+        [
+            ["/sdk-tests-delete-folder-1/test1/test2"],
+            ["sdk-tests-delete-folder/test1/test2"],
+            ["/sdk-tests-delete-folder-1"],
+            ["sdk-tests-delete-folder"],
+        ]
+    )
     def test_delete_folder(self, full_folder_path):
+        create_all_folders_in_path(self.api_factory, full_folder_path)
 
-        create_folder_request = create_all_folders_in_path(self.api_factory, full_folder_path)
+        get_folder_before_delete = drive_object_to_id(
+            self.api_factory, full_folder_path
+        )
 
-        get_folder_before_delete = drive_object_to_id(self.api_factory, full_folder_path)
-
-        delete_folder_request = delete_folder(self.api_factory, full_folder_path)
+        delete_folder(self.api_factory, full_folder_path)
 
         get_folder_after_delete = drive_object_to_id(self.api_factory, full_folder_path)
 
         self.assertTrue(len(get_folder_before_delete) > 0)
         self.assertTrue(len(get_folder_after_delete) == 0)
 
-
-    @parameterized.expand([
-        ["/drive-sdk/path/test/format"],
-        ["/drive-sdk/path/test/format/"],
-        ["drive-sdk/path/test/format"],
-        ["drive-sdk/path/test/format/"]
-    ])
+    @parameterized.expand(
+        [
+            ["/drive-sdk/path/test/format"],
+            ["/drive-sdk/path/test/format/"],
+            ["drive-sdk/path/test/format"],
+            ["drive-sdk/path/test/format/"],
+        ]
+    )
     def test_path_to_search_api_params(self, paths):
-
         search_api_params = path_to_search_api_parms(paths)
 
         self.assertEqual(search_api_params, ("/drive-sdk/path/test", "format"))
 
-    @parameterized.expand([
-        ["/drive-sdk/path/test/format", "/drive-sdk/path/test/format"],
-        ["/drive-sdk/path/test/format/", "/drive-sdk/path/test/format"],
-        ["drive-sdk/path/test/format", "/drive-sdk/path/test/format"],
-        ["drive-sdk/path/test/format/", "/drive-sdk/path/test/format"]
-    ])
+    @parameterized.expand(
+        [
+            ["/drive-sdk/path/test/format", "/drive-sdk/path/test/format"],
+            ["/drive-sdk/path/test/format/", "/drive-sdk/path/test/format"],
+            ["drive-sdk/path/test/format", "/drive-sdk/path/test/format"],
+            ["drive-sdk/path/test/format/", "/drive-sdk/path/test/format"],
+        ]
+    )
     def test_drive_path_formatter(self, input_path, correct_path):
         updated_drive_path = drive_path_formatter(input_path)
         self.assertEqual(updated_drive_path, correct_path)
 
     def test_drive_object_to_id(self):
-
         new_folder_name = "/drive-sdk-test-object-to-id"
-        create_folder_request = create_all_folders_in_path(self.api_factory, new_folder_name)
+        create_all_folders_in_path(self.api_factory, new_folder_name)
 
         base_case_test = drive_object_to_id(self.api_factory, new_folder_name)
         test_no_id = drive_object_to_id(self.api_factory, "folder-not-exist")
@@ -254,7 +286,5 @@ class LusidDriveTests(unittest.TestCase):
         self.assertEqual(len(test_no_id), 0)
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/tests/test_lusid_drive.py
+++ b/sdk/tests/test_lusid_drive.py
@@ -133,9 +133,12 @@ class LusidDriveTests(unittest.TestCase):
         # delete delete test file if exists
         delete_file(cls.delete_test_file_name, cls.test_folder_name)
 
-        # delete test folder
-        folder_id = utilities.get_folder_id(cls.api_factory, cls.test_folder_name)
-        cls.folder_api.delete_folder(folder_id)
+        try:
+            # delete test folder
+            folder_id = utilities.get_folder_id(cls.api_factory, cls.test_folder_name)
+            cls.folder_api.delete_folder(folder_id)
+        except lusid_drive.ApiException:
+            cls.logger.exception(f"failed to delete folder: {cls.test_folder_name}")
 
     def test_get_folder(self):
         get_folder = self.folder_api.get_root_folder(


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Edit some tests, so files and folders are created with randomized names - so that both SDK and SDK preview tests can be run in parallel